### PR TITLE
add case for multiple players claiming same corner spot on first commit

### DIFF
--- a/src/main/kotlin/com/fairviewcodeclub/resk/logic/World.kt
+++ b/src/main/kotlin/com/fairviewcodeclub/resk/logic/World.kt
@@ -58,7 +58,7 @@ class World(val size: Int, colors: Array<ReskColor>) {
 		if (amount > this.numberOfTroopsToCommit || amount == 0) {
 			return false
 		}
-		if (this.nodes[locationId].troops?.owner != this.currentActor && this.territoriesOwnedBy(this.currentActor).isNotEmpty() || this.territoriesOwnedBy(this.currentActor).isEmpty() && !arrayOf(0, size - 1, size * (size - 1), size * size - 1).contains(locationId)) {
+		if (this.nodes[locationId].troops?.owner != this.currentActor && this.territoriesOwnedBy(this.currentActor).isNotEmpty() || this.territoriesOwnedBy(this.currentActor).isEmpty() && !arrayOf(0, size - 1, size * (size - 1), size * size - 1).contains(locationId) || this.territoriesOwnedBy(this.currentActor).isEmpty() && arrayOf(0, size - 1, size * (size - 1), size * size - 1).contains(locationId) && this.nodes[locationId].troops != null) {
 			return false
 		}
 		this.troopOrders.add(TroopOrder(-1, locationId, amount))


### PR DESCRIPTION
When committing troops to a spot, the only cases the can currently cause failure are:
- The current player has territories and is committing to a territory not owned by them
- The current player does not have territories and is committing to a non corner territory

 However, the additional case (below) should be considered:
- The current player does not have territories, is committing to a corner territory, and that territory is owned by somebody

Without this, multiple players can commit to the same corner territory on their first turn.